### PR TITLE
feat: RelatedPostsLayout 생성 및 글로벌 스타일 수정(#38)

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -19,7 +19,11 @@ module.exports = {
     'import/no-extraneous-dependencies': 0, // 테스트 또는 개발환경을 구성하는 파일에서는 devDependency 사용을 허용
     'no-shadow': 0,
     'react/prop-types': 0,
-    'react/jsx-filename-extension': [2, { extensions: ['.js', '.jsx', '.ts', '.tsx'] }],
+    'react/jsx-filename-extension': [
+      2,
+      { extensions: ['.js', '.jsx', '.ts', '.tsx'] },
+    ],
     'jsx-a11y/no-noninteractive-element-interactions': 0,
+    '@typescript-eslint/explicit-function-return-type': 'off',
   },
 };

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ThemeProvider } from 'styled-components';
-import App from './App';
 import GlobalStyle from 'style/GlobalStyle';
 import theme from 'style/theme';
+import RelatedPosts from 'layout/RelatedPosts';
+import App from './App';
 
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <App />
       <GlobalStyle />
+      <RelatedPosts />
     </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/client/src/layout/RelatedPosts/index.tsx
+++ b/client/src/layout/RelatedPosts/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import * as S from './style';
+
+export default function RelatedPosts(): JSX.Element {
+  return (
+    <>
+      <S.RelatedPostsContainer />
+    </>
+  );
+}

--- a/client/src/layout/RelatedPosts/style.ts
+++ b/client/src/layout/RelatedPosts/style.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const RelatedPostsContainer = styled.div`
+  max-width: 920px;
+  height: 500px;
+  border: 1px solid black;
+  margin-left: 8rem;
+`;

--- a/client/src/style/GlobalStyle.ts
+++ b/client/src/style/GlobalStyle.ts
@@ -6,6 +6,10 @@ const GlobalStyle = createGlobalStyle`
     padding: 0;
   }
   body {
+    max-width: 1440px;
+    margin: auto;
+    min-height: 100vh;
+    border: 3px solid tomato;
     box-sizing: border-box;
     font-family: Helvetica, Arial, sans-serif;
     background-color: #F8FAFB;


### PR DESCRIPTION
## 개요

- RelatedPostsLayout 잡기
- 글로벌 스타일 수정

## 작업사항

- RelatedPostsLayout 생성
- Figma 수치 참고했으며, 개발하면서 추후 수정
- 가이드라인 추가 (추후 삭제 예정)

- 글로벌 screen size (1440px)
- 양 옆 패딩 (8rem)
- 가이드라인 추가 (추후 삭제 예정)

<img width="1111" alt="Screen Shot 2021-04-29 at 2 43 39 PM" src="https://user-images.githubusercontent.com/76833697/116506964-51585a80-a8f9-11eb-94c8-f9f79e3d6eee.png">

## 참고

- [Figma](https://www.figma.com/file/kWTftt92RmQaIPcZf5Kw56/LCTP-TEAM-6?node-id=1%3A2)

## 연결된 이슈

closes #38
