### PR TITLE
feat: RelatedPostsHeader / Body 생성(#40)

### DIFF
--- a/client/src/layout/RelatedPosts/index.tsx
+++ b/client/src/layout/RelatedPosts/index.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import * as S from './style';
+import RelatedPostsHeader from '../RelatedPostsHeader';
+import RelatedPostsBody from '../RelatedPostsBody';
 
 export default function RelatedPosts(): JSX.Element {
   return (
-    <>
-      <S.RelatedPostsContainer />
-    </>
+    <S.RelatedPostsContainer>
+      <RelatedPostsHeader />
+      <RelatedPostsBody />
+    </S.RelatedPostsContainer>
   );
 }

--- a/client/src/layout/RelatedPostsBody/index.tsx
+++ b/client/src/layout/RelatedPostsBody/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import * as S from './style';
+
+export default function RelatedPostsBody(): JSX.Element {
+  return <S.RelatedPostsBodyContainer />;
+}

--- a/client/src/layout/RelatedPostsBody/style.ts
+++ b/client/src/layout/RelatedPostsBody/style.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const RelatedPostsBodyContainer = styled.div`
+  width: 100%;
+  height: 450px;
+  border: 1px solid blueviolet;
+`;

--- a/client/src/layout/RelatedPostsHeader/index.tsx
+++ b/client/src/layout/RelatedPostsHeader/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import * as S from './style';
+
+export default function RelatedPostsHeader(): JSX.Element {
+  return <S.RelatedPostsHeaderContainer />;
+}

--- a/client/src/layout/RelatedPostsHeader/style.ts
+++ b/client/src/layout/RelatedPostsHeader/style.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const RelatedPostsHeaderContainer = styled.div`
+  width: 100%;
+  height: 50px;
+  border: 1px solid tomato;
+`;


### PR DESCRIPTION
## 개요

- RelatedPostsHeader / Body 생성

## 작업사항

- RelatedPostsHeader / Body 레이아웃 추가

<img width="1129" alt="Screen Shot 2021-04-29 at 4 36 24 PM" src="https://user-images.githubusercontent.com/76833697/116516860-1b22d700-a909-11eb-8252-75aeb42e6c2f.png">

## 참고

- [Figma](https://www.figma.com/file/kWTftt92RmQaIPcZf5Kw56/LCTP-TEAM-6?node-id=0%3A1)

## 연결된 이슈

- closes #40 
