### PR TITLE
feat: RelatedPostsHeader Components 추가(#42)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function App() {
+function App(): JSX.Element {
   return <div />;
 }
 

--- a/client/src/components/Button/index.tsx
+++ b/client/src/components/Button/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import * as S from './style';
+
+interface Props {
+  title: string;
+}
+
+export default function Button({ title }: Props): JSX.Element {
+  return <S.Button>{title}</S.Button>;
+}

--- a/client/src/components/Button/style.ts
+++ b/client/src/components/Button/style.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Button = styled.button`
+  border: 0;
+  border-radius: 50px;
+  padding: 10px 20px 10px 20px;
+  background-color: #125ff4;
+  color: white;
+  &:hover {
+    cursor: pointer;
+  }
+`;

--- a/client/src/layout/RelatedPostsHeader/index.tsx
+++ b/client/src/layout/RelatedPostsHeader/index.tsx
@@ -1,6 +1,23 @@
 import React from 'react';
+import Button from 'components/Button';
 import * as S from './style';
 
 export default function RelatedPostsHeader(): JSX.Element {
-  return <S.RelatedPostsHeaderContainer />;
+  return (
+    <S.Container>
+      <S.HeaderContainer>
+        <S.TitleWrapper>
+          <S.Title>Related Posts</S.Title>
+        </S.TitleWrapper>
+        <S.LinkWrapper>
+          <S.Link>Week</S.Link>
+          <S.Link>Latest</S.Link>
+          <S.Link>Feed</S.Link>
+        </S.LinkWrapper>
+        <S.ButtonWrapper>
+          <Button title="Create New Posts" />
+        </S.ButtonWrapper>
+      </S.HeaderContainer>
+    </S.Container>
+  );
 }

--- a/client/src/layout/RelatedPostsHeader/style.ts
+++ b/client/src/layout/RelatedPostsHeader/style.ts
@@ -1,7 +1,37 @@
 import styled from 'styled-components';
 
-export const RelatedPostsHeaderContainer = styled.div`
+export const Container = styled.div`
+  padding-right: 1rem;
+`;
+
+export const HeaderContainer = styled.div`
   width: 100%;
   height: 50px;
-  border: 1px solid tomato;
+  display: flex;
+  align-items: flex-end;
+`;
+
+export const TitleWrapper = styled.div`
+  min-width: 220px;
+`;
+
+export const Title = styled.h2`
+  font-size: 30px;
+`;
+
+export const LinkWrapper = styled.div`
+  min-width: 200px;
+  display: flex;
+  justify-content: space-around;
+`;
+
+export const Link = styled.span`
+  color: #9b9b9b;
+  font-size: 20px;
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
 `;


### PR DESCRIPTION
## 개요

- RelatedPostsHeader의 Components 추가

## 작업사항

- RelatedPostsHeader의 Title, Link, Button 추가
- 기능 구현 예정

<img width="1614" alt="Screen Shot 2021-04-29 at 6 50 37 PM" src="https://user-images.githubusercontent.com/76833697/116533754-b70a0e00-a91c-11eb-8a3e-d35a795fab51.png">

## 참고

- [Figma](https://www.figma.com/file/kWTftt92RmQaIPcZf5Kw56/LCTP-TEAM-6?node-id=0%3A1)

## 연결된 이슈

- closes #42 
