### PR TITLE
feat: 로그인 페이지 컴포넌트 설정(#58)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'styled-components';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import Main from 'pages/Main';
 import Login from 'pages/Login';
+import { HOME_URL, LOGIN_URL } from 'commons/constants/string';
 
 function App(): JSX.Element {
   return (
@@ -13,8 +14,8 @@ function App(): JSX.Element {
         <GlobalStyle />
         <Router>
           <Switch>
-            <Route exact path="/" component={Main} />
-            <Route exact path="/login" component={Login} />
+            <Route exact path={HOME_URL} component={Main} />
+            <Route exact path={LOGIN_URL} component={Login} />
           </Switch>
         </Router>
       </ThemeProvider>

--- a/client/src/commons/constants/string.ts
+++ b/client/src/commons/constants/string.ts
@@ -1,3 +1,16 @@
+export const HOME_URL = '/';
+export const SIGN_UP_URL = '/signup';
+export const LOGIN_URL = '/login';
+export const TEAM_GITHUB_URL =
+  'https://github.com/LM-channel-team-project/team6';
+
 export const RELATED_POSTS_TITLE = 'Related Posts';
 export const RELATED_POSTS_CREATE_BUTTON = 'Create New Posts';
 export const RELATED_POSTS_SORT = ['Week', 'Latest', 'Feed'];
+
+export const LOGIN_TITLE = '로그인';
+export const LOGIN_LINK_TEXT = 'TEAM 6';
+export const LOGIN_WELCOME_TEXT = '블로그에 오신 것을 환영합니다.';
+
+export const SIGN_UP_LINK_TEXT = '회원가입';
+export const SIGN_UP_WELCOME_TEXT = '혹시 처음 오셨나요?';

--- a/client/src/components/atoms/BasicText/index.tsx
+++ b/client/src/components/atoms/BasicText/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import * as S from './style';
+
+interface Props {
+  text: string;
+}
+
+export default function BasicText({ text }: Props): JSX.Element {
+  return (
+    <S.Container>
+      <S.Text>{text}</S.Text>
+    </S.Container>
+  );
+}

--- a/client/src/components/atoms/BasicText/style.ts
+++ b/client/src/components/atoms/BasicText/style.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Container = styled.div``;
+
+export const Text = styled.p`
+  color: #7c7c7c;
+`;

--- a/client/src/components/atoms/ExternalLink/index.tsx
+++ b/client/src/components/atoms/ExternalLink/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import * as S from './style';
+
+interface Props {
+  href: string;
+  text: string;
+}
+
+export default function ExternalLink({ href, text }: Props): JSX.Element {
+  return (
+    <S.Container>
+      <S.Anchor href={href} target="_blank">
+        <S.Text>{text}</S.Text>
+      </S.Anchor>
+    </S.Container>
+  );
+}

--- a/client/src/components/atoms/ExternalLink/style.ts
+++ b/client/src/components/atoms/ExternalLink/style.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Container = styled.div``;
+
+export const Anchor = styled.a`
+  color: #9564ff;
+  font-weight: 600;
+`;
+
+export const Text = styled.p``;

--- a/client/src/components/atoms/InternalLink/index.tsx
+++ b/client/src/components/atoms/InternalLink/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import * as S from './style';
+
+interface Props {
+  href: string;
+  text: string;
+}
+
+export default function InternalLink({ href, text }: Props): JSX.Element {
+  return (
+    <S.Container>
+      <S.InternalLink to={href}>
+        <S.Text>{text}</S.Text>
+      </S.InternalLink>
+    </S.Container>
+  );
+}

--- a/client/src/components/atoms/InternalLink/style.ts
+++ b/client/src/components/atoms/InternalLink/style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
+export const Container = styled.div``;
+
+export const InternalLink = styled(Link)`
+  color: #9564ff;
+  font-weight: 600;
+`;
+
+export const Text = styled.p``;

--- a/client/src/components/atoms/LoginTitle/index.tsx
+++ b/client/src/components/atoms/LoginTitle/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { LOGIN_TITLE } from 'commons/constants/string';
+import * as S from './style';
+
+export default function LoginTitle(): JSX.Element {
+  return (
+    <S.Container>
+      <S.Title>{LOGIN_TITLE}</S.Title>
+    </S.Container>
+  );
+}

--- a/client/src/components/atoms/LoginTitle/style.ts
+++ b/client/src/components/atoms/LoginTitle/style.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const Container = styled.div``;
+
+export const Title = styled.h2`
+  color: #7c7c7c;
+  font-size: 3rem;
+`;

--- a/client/src/components/molecules/LoginBody/index.tsx
+++ b/client/src/components/molecules/LoginBody/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import BasicText from 'components/atoms/BasicText';
+import InternalLink from 'components/atoms/InternalLink';
+import {
+  SIGN_UP_URL,
+  SIGN_UP_WELCOME_TEXT,
+  SIGN_UP_LINK_TEXT,
+} from 'commons/constants/string';
+import * as S from './style';
+
+export default function LoginBody(): JSX.Element {
+  return (
+    <S.Container>
+      <S.ButtonContainer />
+      <S.LinkContainer>
+        <BasicText text={SIGN_UP_WELCOME_TEXT} />
+        &nbsp;
+        <InternalLink href={SIGN_UP_URL} text={SIGN_UP_LINK_TEXT} />
+      </S.LinkContainer>
+    </S.Container>
+  );
+}

--- a/client/src/components/molecules/LoginBody/style.ts
+++ b/client/src/components/molecules/LoginBody/style.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Container = styled.div``;
+
+export const ButtonContainer = styled.div`
+  width: 400px;
+  height: 250px;
+  border: 2px solid tomato;
+  border-radius: 30px;
+  margin-top: 2rem;
+`;
+
+export const LinkContainer = styled.div`
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+`;

--- a/client/src/components/molecules/LoginHeader/index.tsx
+++ b/client/src/components/molecules/LoginHeader/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import LoginTitle from 'components/atoms/LoginTitle';
+import ExternalLink from 'components/atoms/ExternalLink';
+import BasicText from 'components/atoms/BasicText';
+import {
+  LOGIN_LINK_TEXT,
+  TEAM_GITHUB_URL,
+  LOGIN_WELCOME_TEXT,
+} from 'commons/constants/string';
+import * as S from './style';
+
+export default function LoginHeader(): JSX.Element {
+  return (
+    <S.Container>
+      <S.TitleWrapper>
+        <LoginTitle />
+      </S.TitleWrapper>
+      <S.LinkContentWrapper>
+        <ExternalLink text={LOGIN_LINK_TEXT} href={TEAM_GITHUB_URL} />
+        &nbsp;
+        <BasicText text={LOGIN_WELCOME_TEXT} />
+      </S.LinkContentWrapper>
+    </S.Container>
+  );
+}

--- a/client/src/components/molecules/LoginHeader/style.ts
+++ b/client/src/components/molecules/LoginHeader/style.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const TitleWrapper = styled.div`
+  margin-top: 4rem;
+`;
+
+export const LinkContentWrapper = styled.div`
+  display: flex;
+`;

--- a/client/src/components/organisms/LoginContent/index.tsx
+++ b/client/src/components/organisms/LoginContent/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import LoginHeader from 'components/molecules/LoginHeader';
+import LoginBody from 'components/molecules/LoginBody';
+import * as S from './style';
+
+export default function LoginContent(): JSX.Element {
+  return (
+    <S.Container>
+      <LoginHeader />
+      <LoginBody />
+    </S.Container>
+  );
+}

--- a/client/src/components/organisms/LoginContent/style.ts
+++ b/client/src/components/organisms/LoginContent/style.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  background-color: white;
+  width: 448px;
+  height: 550px;
+  border-radius: 30px;
+  box-shadow: 5px 5px 10px gray;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;

--- a/client/src/components/templates/LoginTemplate/index.tsx
+++ b/client/src/components/templates/LoginTemplate/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import Doge from 'assets/image/doge.png';
+import LoginContent from 'components/organisms/LoginContent';
 import * as S from './style';
 
 export default function LoginTemplate(): JSX.Element {
   return (
     <S.Container>
       <S.Img src={Doge} alt="Doge" />
-      <S.ContentContainer />
+      <LoginContent />
     </S.Container>
   );
 }

--- a/client/src/components/templates/LoginTemplate/style.ts
+++ b/client/src/components/templates/LoginTemplate/style.ts
@@ -5,14 +5,6 @@ export const Container = styled.div`
   z-index: 1000;
 `;
 
-export const ContentContainer = styled.div`
-  background-color: white;
-  width: 448px;
-  height: 550px;
-  border-radius: 30px;
-  box-shadow: 5px 5px 10px gray;
-`;
-
 export const ImgContainer = styled.div``;
 
 export const Img = styled.img`


### PR DESCRIPTION
## 개요

- 로그인 페이지 컴포넌트 설정

## 작업사항

- 로그인 페이지 전체 컨포넌트 추가
- 로그인 텍스트, 외부 링크 (Team6 Github Repo로 연결) 설정
- 로그인 버튼 컴포넌트 설정
- 회원가입 텍스트, 내부 링크 (/signup) 설정
- 각 링크 문자열 상수로 분리 (constants)

<img width="400" alt="Screen Shot 2021-05-05 at 6 33 23 PM" src="https://user-images.githubusercontent.com/76833697/117122766-2f674800-add1-11eb-8b49-a0475ce1ec2f.png">

## 참고

- [Figma](https://www.figma.com/file/kWTftt92RmQaIPcZf5Kw56/LCTP-TEAM-6?node-id=0%3A1)

## 연결된 이슈

- closes: #58 
