### PR TITLE
feat: 회원가입 폼 유효성 검사 추가(#82)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,8 +17,8 @@ function App(): JSX.Element {
         <Router>
           <Switch>
             <Route exact path={HOME_URL} component={Main} />
-            <Route exact path={LOGIN_URL} component={Login} />
-            <Route exact path={SIGN_UP_URL} component={SignUp} />
+            <Route path={LOGIN_URL} component={Login} />
+            <Route path={SIGN_UP_URL} component={SignUp} />
             <Route path="/detail/:id" component={Detail} />
           </Switch>
         </Router>

--- a/client/src/commons/style/GlobalStyle.ts
+++ b/client/src/commons/style/GlobalStyle.ts
@@ -6,7 +6,6 @@ const GlobalStyle = createGlobalStyle`
     padding: 0;
   }
   body {
-    max-width: 1440px;
     margin: auto;
     min-height: 100vh;
     box-sizing: border-box;

--- a/client/src/components/atoms/SignButton/style.ts
+++ b/client/src/components/atoms/SignButton/style.ts
@@ -18,6 +18,7 @@ export const Button = styled.button<ButtonProps>`
     border: 1px solid #9664ff;
   }
   background: ${(props) => props.background || 'white'};
+  background: ${(props) => (props.disabled ? 'gray' : props.background)};
   color: ${(props) => props.color || 'black'};
 `;
 

--- a/client/src/components/molecules/SignUpFormBody/index.tsx
+++ b/client/src/components/molecules/SignUpFormBody/index.tsx
@@ -8,6 +8,7 @@ import {
   PLACEHOLDER_CONFIRM_PW,
   SIGN_UP_POST_API,
 } from 'commons/constants/string';
+import { signUpValidateInput } from 'utils/signUpValidateInput';
 import axios from 'axios';
 import * as S from './style';
 
@@ -20,6 +21,13 @@ export default function SignUpFormBody(): JSX.Element {
   });
 
   const { username, email, password, confirmPassword } = inputs;
+
+  const isEnabled = signUpValidateInput(
+    username,
+    email,
+    password,
+    confirmPassword,
+  );
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -42,10 +50,10 @@ export default function SignUpFormBody(): JSX.Element {
       },
     })
       .then((res) => {
-        alert(`${res.status}: 회원가입 성공`);
+        alert(`${res.status}: 회원가입 성공`); // eslint-disable-line no-alert
       })
       .catch((error) => {
-        alert(`${error}: 오류발생`);
+        alert(`${error}: 오류발생`); // eslint-disable-line no-alert
       });
   };
 
@@ -85,6 +93,7 @@ export default function SignUpFormBody(): JSX.Element {
           background="#9564FF"
           color="white"
           type="submit"
+          disabled={!isEnabled}
         />
       </S.Form>
     </S.Container>

--- a/client/src/utils/signUpValidateInput/index.ts
+++ b/client/src/utils/signUpValidateInput/index.ts
@@ -1,0 +1,21 @@
+export function signUpValidateInput(
+  username: string,
+  email: string,
+  password: string,
+  confirmPassword: string,
+): boolean {
+  const emailValidation = new RegExp(
+    /^(("[\w-\s]+")|([\w-]+(?:\.[\w-]+)*)|("[\w-\s]+")([\w-]+(?:\.[\w-]+)*))(@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$)|(@\[?((25[0-5]\.|2[0-4][0-9]\.|1[0-9]{2}\.|[0-9]{1,2}\.))((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){2}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\]?$)/i,
+  );
+  if (
+    username.length > 1 &&
+    email.length > 6 &&
+    emailValidation.test(email) &&
+    password.length > 6 &&
+    confirmPassword.length > 6 &&
+    password === confirmPassword
+  ) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## 개요

- 회원가입 폼 유효성 검사
- 글로벌 스타일의 `max-width` 제거
- 라우터 `exact` 옵션 제거

## 작업사항

- 회원가입 폼 유효성 검사
  - **username**: 1글자 이상
  - **email**: 5글자 이상 및 email 형식 준수
  - **password**: 6글자 이상
  - **confirmPassword**: password와 일치여부
- 유틸함수를 위한 `src / utils` 디렉토리 생성
- 글로벌 스타일 `max-width` 제거 (내부 컴포넌트에서 너비 설정)
- 라우터 `exact` 옵션 제거 (`Home`만 적용)

<br>

- 폼 유효성 검사 실패시
<img width="500" alt="Screen Shot 2021-05-21 at 1 45 24 PM" src="https://user-images.githubusercontent.com/76833697/119083900-d12a9e00-ba3b-11eb-8cea-dfa8228540bb.png">

- 폼 유효성 검사 성공시
<img width="500" alt="Screen Shot 2021-05-21 at 1 45 38 PM" src="https://user-images.githubusercontent.com/76833697/119083915-d7207f00-ba3b-11eb-96de-19be8003bfee.png">

## 참고

## 연결된 이슈

- closes #82
