### PR TITLE
refactor: 이메일 로그인 텍스트 수정 및 로그인 페이지 푸쉬 (#105)

### DIFF
--- a/client/src/commons/constants/string.ts
+++ b/client/src/commons/constants/string.ts
@@ -19,7 +19,7 @@ export const LOGIN_EMAIL_ALT = 'Email Login';
 
 // LOGIN EMAIL
 export const LOGIN_EMAIL_TITLE = '이메일로 로그인';
-export const LOGIN_EMAIL_BACK_TEXT = '다른방법으로 로그인하기';
+export const LOGIN_EMAIL_BACK_TEXT = '다른 방법으로 로그인하기';
 
 // SIGN UP
 export const SIGN_UP_LINK_TEXT = '회원가입';

--- a/client/src/components/molecules/SignUpBody/index.tsx
+++ b/client/src/components/molecules/SignUpBody/index.tsx
@@ -7,12 +7,15 @@ import {
   PLACEHOLDER_PW,
   PLACEHOLDER_CONFIRM_PW,
   SIGN_UP_POST_API,
+  LOGIN_EMAIL_URL,
 } from 'commons/constants/string';
 import { signUpValidateInput } from 'utils/signUpValidateInput';
 import axios from 'axios';
+import { useHistory } from 'react-router-dom';
 import * as S from './style';
 
 export default function SignUpBody(): JSX.Element {
+  const history = useHistory();
   const [inputs, setInputs] = useState({
     username: '',
     email: '',
@@ -51,6 +54,7 @@ export default function SignUpBody(): JSX.Element {
     })
       .then((res) => {
         alert(`${res.status}: 회원가입 성공`); // eslint-disable-line no-alert
+        history.push(LOGIN_EMAIL_URL);
       })
       .catch((error) => {
         alert(`${error}: 오류발생`); // eslint-disable-line no-alert


### PR DESCRIPTION
## 개요

- 텍스트 수정 및 페이지 푸쉬

## 작업사항

- 이메일 로그인 텍스트 수정 (띄어쓰기)
- 회원 가입 성공 후 로그인 페이지로 푸쉬

## 참고

## 연결된 이슈

- closes #105 
